### PR TITLE
Upgrade build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Old gradle version 1.3.0 doesn't work. Needs to upgrade to 2.1.0. 
http://stackoverflow.com/questions/39675848/unsupportedmethodexception-android-studio-2-2
Can't be upgraded to 2.3.0 because that would not work either due to instant run.